### PR TITLE
Closes #188 - change `target` to `id` in `showPopover` example code

### DIFF
--- a/R/popover.R
+++ b/R/popover.R
@@ -44,7 +44,7 @@
 #' server <- function(input, output) {
 #'   observeEvent(input$showHelp, ignoreInit = TRUE, {
 #'     showPopover(
-#'       target = "textBlock1",
+#'       id = "textBlock1",
 #'       popover(title = "Hint", "I am a <div> element!"),
 #'       placement = "bottom",
 #'       duration = 4


### PR DESCRIPTION
Closing issue #188 in hopefully a simple manner. New example function works as expected:

```
ui <- container(
  buttonInput("showHelp", "Help!"),
  div(
    id = "textBlock1",
    "Sociis natoque penatibus et magnis"
  ) %>%
    padding(3)
) %>%
  display("flex") %>%
  flex(justify = "around")

server <- function(input, output) {
  observeEvent(input$showHelp, ignoreInit = TRUE, {
    showPopover(
      id = "textBlock1",
      popover(title = "Hint", "I am a <div> element!"),
      placement = "bottom",
      duration = 4
    )
  })
}

shinyApp(ui, server)
```