### PR TITLE
ops(gh actions): supersede pull request runs, cap job time

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,9 +9,19 @@ name: R-CMD-check.yaml
 
 permissions: read-all
 
+# A newer commit on a pull request supersedes whatever is still running for
+# it. Runs on `main` are left alone so every commit keeps its own result.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
+
+    # The slowest healthy leg runs well under 10 minutes. A job past this
+    # is wedged, and without a limit it holds its runner for 6 hours.
+    timeout-minutes: 45
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -9,9 +9,18 @@ name: test-coverage.yaml
 
 permissions: read-all
 
+# A newer commit on a pull request supersedes whatever is still running for
+# it. Runs on `main` are left alone so every commit keeps its own result.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
+
+    timeout-minutes: 30
+
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       TESTTHAT_CPUS: 3


### PR DESCRIPTION
Two problems showed up while running CI for #228.

A push to the pull request left the previous run going, because neither workflow declares a `concurrency` group. The superseded run held its runners for close to two hours before it was cancelled by hand. Runs are now grouped by ref, and the older one is cancelled — except on `main`, where `cancel-in-progress` evaluates to `false` so every commit keeps its own check result and its own coverage upload. Each workflow's `github.workflow` differs, so R-CMD-check and test-coverage key to separate groups and never cancel each other.

Separately, `ubuntu-latest (release)` and `ubuntu-latest (oldrel-1)` wedged in `setup-r-dependencies` on two independent runs, one for 31 minutes and one for nearly two hours, while `ubuntu-latest (devel)` passed on the same run in 7m50s. Without `timeout-minutes` a job like that occupies a runner until the 6 hour ceiling. R-CMD-check now caps at 45 minutes and test-coverage at 30; the slowest healthy legs are 7m53s and 6m24s, so there is ample headroom.

Re-running the two stuck jobs cleared them with no code change, and GitHub, Posit Package Manager, and CRAN all reported healthy at the time, so the stalls look transient rather than reproducible. The timeout is there to bound the next one.

Note that CI on this branch only exercises half the change: the timeouts and the pull request side of `cancel-in-progress` run here, but the `main` branch behaviour cannot be observed until something lands there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)